### PR TITLE
Add configuration options similar to Permit.Phoenix

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,23 @@ field :create_post, :post do
 end
 ```
 
+### Customisation options
+
+The `permit` macro supports a set of options that let you customize how Permit Absinthe loads data, scopes Ecto queries, and formats success/errors.
+
+- **`:fetch_subject`**: function to fetch the “subject” (usually current user) from the resolution context (defaults to `resolution.context[:current_user]`).
+- **`:base_query`**: function to build a custom Ecto base query *before* Permit scoping is applied (useful for soft deletes / tenancy / additional filters).
+- **`:finalize_query`**: function to post-process the Ecto query *after* Permit scoping is applied (useful for sorting / pagination).
+- **`:handle_unauthorized`**: function called when authorization fails or when the subject is missing; should return `{:error, message}` (or `{:ok, value}` if you intentionally want to return a safe fallback).
+- **`:handle_not_found`**: function called when the resource cannot be found; should return `{:error, message}`.
+- **`:unauthorized_message`**: custom string message used on unauthorized access (only when `:handle_unauthorized` is not set).
+- **`:loader`**: function to load data from a custom source (external API, cache, etc.) instead of the default Ecto/Dataloader-based loading.
+- **`:wrap_authorized`**: function called on successful authorization; should return `{:ok, value}` (or `{:error, message}`) to reshape/redact the returned data.
+
+#### Important caveat about callbacks
+
+Permit Absinthe captures callback functions passed to `permit` (for example `permit loader: &external_notes_loader/1`) as AST at compile time to avoid Absinthe boilerplate. References, function calls, and aliases are supported, but **functions defined in your schema module must be public** (use `def`, not `defp`).
+
 ### Using authorization resolvers
 
 Permit.Absinthe provides resolver functions to load and authorize resources automatically:

--- a/lib/permit_absinthe.ex
+++ b/lib/permit_absinthe.ex
@@ -106,19 +106,87 @@ defmodule Permit.Absinthe do
         # ...
       end
 
+  Custom base query for nested resources:
+
+      field :user_article, :article do
+        arg :user_id, non_null(:id)
+        arg :id, non_null(:id)
+
+        permit action: :read,
+               base_query: fn %{params: %{user_id: user_id, id: id}} ->
+                 from a in Article,
+                   where: a.id == ^id,
+                   where: a.author_id == ^user_id
+               end
+      end
+
+  Custom subject fetching:
+
+      field :article, :article do
+        permit action: :read,
+               fetch_subject: fn %{resolution: resolution} ->
+                 # Extract from custom header or token
+                 get_user_from_token(resolution.context[:token])
+               end
+      end
+
+  Custom error handling:
+
+      field :article, :article do
+        permit action: :read,
+               handle_unauthorized: fn %{action: action} ->
+                 {:error, %{message: "Cannot \#{action}", code: "FORBIDDEN"}}
+               end,
+               handle_not_found: fn %{params: params} ->
+                 {:error, %{message: "Not found", params: params}}
+               end
+      end
+
+  Custom loader (non-Ecto):
+
+      field :article, :article do
+        permit action: :read,
+               loader: fn %{params: %{id: id}} ->
+                 ExternalAPI.fetch_article(id)
+               end
+      end
+
   Options:
   - `:schema` - Ecto schema this type represents
   - `:action` - Action to authorize (required for mutations, defaults to `:read`)
   - `:id_param_name` - Parameter name for lookups (defaults to `:id`)
   - `:id_struct_field_name` - Struct field to match against (defaults to `:id`)
+  - `:base_query` - Function to build custom base query (receives context map)
+  - `:finalize_query` - Function to post-process query (receives query and context)
+  - `:fetch_subject` - Function to extract current user (receives context map)
+  - `:handle_unauthorized` - Function to handle authorization failure (receives context map)
+  - `:handle_not_found` - Function to handle resource not found (receives context map)
+  - `:unauthorized_message` - Simple string message for unauthorized (only if handle_unauthorized not set)
+  - `:loader` - Custom loader function for non-Ecto data sources (receives context map)
+  - `:wrap_authorized` - Function to wrap successful response (receives loaded resource)
   """
 
   defmacro permit(opts) do
     authorization_module = Module.get_attribute(__CALLER__.module, :authorization_module)
 
+    config_opts = [
+      :schema,
+      :action,
+      :id_param_name,
+      :id_struct_field_name,
+      :base_query,
+      :finalize_query,
+      :fetch_subject,
+      :handle_unauthorized,
+      :handle_not_found,
+      :unauthorized_message,
+      :loader,
+      :wrap_authorized
+    ]
+
     quote do
       meta(
-        permit: unquote(opts),
+        permit: unquote(Keyword.take(opts, config_opts)),
         authorization_module: unquote(authorization_module)
       )
     end

--- a/lib/permit_absinthe.ex
+++ b/lib/permit_absinthe.ex
@@ -184,9 +184,11 @@ defmodule Permit.Absinthe do
       :wrap_authorized
     ]
 
+    permit_opts = Keyword.take(opts, config_opts)
+
     quote do
       meta(
-        permit: unquote(Keyword.take(opts, config_opts)),
+        permit: unquote(permit_opts),
         authorization_module: unquote(authorization_module)
       )
     end

--- a/lib/permit_absinthe/load_and_authorize.ex
+++ b/lib/permit_absinthe/load_and_authorize.ex
@@ -3,6 +3,7 @@ defmodule Permit.Absinthe.LoadAndAuthorize do
   This module contains the load_and_authorize/2 function that can be used from within
   a custom resolver function, or as a resolver function in its entirety.
   """
+
   alias Permit.Absinthe.Schema.{Helpers, Meta}
 
   @doc """
@@ -50,28 +51,184 @@ defmodule Permit.Absinthe.LoadAndAuthorize do
     authorization_module =
       Meta.get_field_meta_from_resolution(resolution, :authorization_module)
 
-    arity = determine_arity(resolution)
+    resolution_context =
+      build_resolution_context(args, resolution, field_meta, type_meta, authorization_module)
 
-    case authorization_module.resolver_module().resolve(
-           resolution.context[:current_user],
-           authorization_module,
-           module,
-           action,
-           %{
-             params: args,
-             resolution: resolution,
-             base_query: field_meta[:base_query] || (&Helpers.base_query/1)
-           },
-           arity
-         ) do
-      {:authorized, resource} ->
+    subject = fetch_subject(resolution_context, field_meta)
+
+    if is_nil(subject) do
+      handle_unauthorized(resolution_context, field_meta)
+    else
+      arity = determine_arity(resolution)
+
+      case authorize_and_load(
+             subject,
+             authorization_module,
+             module,
+             action,
+             resolution_context,
+             arity
+           ) do
+        {:authorized, resource} ->
+          wrap_authorized_response(resource, field_meta)
+
+        :unauthorized ->
+          handle_unauthorized(resolution_context, field_meta)
+
+        :not_found ->
+          handle_not_found(resolution_context, field_meta)
+      end
+    end
+  end
+
+  defp build_resolution_context(args, resolution, field_meta, type_meta, authorization_module) do
+    %{
+      params: args,
+      resolution: resolution,
+      field_meta: field_meta,
+      type_meta: type_meta,
+      action: field_meta[:action] || Helpers.default_action(resolution),
+      resource_module: type_meta[:schema],
+      authorization_module: authorization_module,
+      base_query:
+        field_meta |> get_field(:base_query) |> get_fn_from_ast(1) || (&Helpers.base_query/1),
+      finalize_query: field_meta |> get_field(:finalize_query) |> get_fn_from_ast(2)
+    }
+  end
+
+  defp get_field(meta, key) do
+    cond do
+      is_map(meta) -> meta[key]
+      is_list(meta) -> Keyword.get(meta, key)
+      true -> nil
+    end
+  end
+
+  defp get_fn_from_ast(value, arity \\ 1)
+
+  defp get_fn_from_ast(f, arity) when is_function(f, arity), do: f
+
+  defp get_fn_from_ast({:fn, _meta, _clauses} = fn_ast, arity) do
+    with {function, _} <- Code.eval_quoted(fn_ast, []),
+         true <- is_function(function, arity) do
+      function
+    else
+      _ -> nil
+    end
+  rescue
+    _ -> nil
+  end
+
+  defp get_fn_from_ast(_, _), do: nil
+
+  defp fetch_subject(context, field_meta) do
+    case field_meta |> get_field(:fetch_subject) |> get_fn_from_ast() do
+      nil ->
+        context.resolution.context[:current_user]
+
+      fetch_subject_fn ->
+        try do
+          fetch_subject_fn.(context)
+        rescue
+          _ -> nil
+        end
+    end
+  end
+
+  defp handle_unauthorized(context, field_meta) do
+    case field_meta |> get_field(:handle_unauthorized) |> get_fn_from_ast() do
+      nil ->
+        message = field_meta[:unauthorized_message] || "Unauthorized"
+        {:error, message}
+
+      handle_unauthorized_fn ->
+        try do
+          handle_unauthorized_fn.(context)
+        rescue
+          _ -> {:error, "Unauthorized"}
+        end
+    end
+  end
+
+  defp handle_not_found(context, field_meta) do
+    case field_meta |> get_field(:handle_not_found) |> get_fn_from_ast() do
+      nil ->
+        {:error, "Not found"}
+
+      handle_not_found_fn ->
+        try do
+          handle_not_found_fn.(context)
+        rescue
+          _ -> {:error, "Not found"}
+        end
+    end
+  end
+
+  defp wrap_authorized_response(resource, field_meta) do
+    case field_meta |> get_field(:wrap_authorized) |> get_fn_from_ast() do
+      nil ->
         {:ok, resource}
 
-      :unauthorized ->
-        {:error, "Unauthorized"}
+      wrap_authorized_fn ->
+        try do
+          case wrap_authorized_fn.(resource) do
+            {:ok, wrapped_resource} ->
+              {:ok, wrapped_resource}
 
-      :not_found ->
-        {:error, "Not found"}
+            {:error, error} ->
+              {:error, error}
+
+            _ ->
+              {:error, "wrap_authorized function returned invalid type"}
+          end
+        rescue
+          _ -> {:error, "wrap_authorized function raised an exception"}
+        end
+    end
+  end
+
+  defp authorize_and_load(subject, authorization_module, module, action, context, arity) do
+    case context.field_meta |> get_field(:loader) |> get_fn_from_ast() do
+      nil ->
+        meta = %{
+          params: context.params,
+          resolution: context.resolution,
+          base_query: context.base_query,
+          finalize_query: context.finalize_query || fn query, _ctx -> query end
+        }
+
+        authorization_module.resolver_module().resolve(
+          subject,
+          authorization_module,
+          module,
+          action,
+          meta,
+          arity
+        )
+
+      loader_fn ->
+        loaded =
+          try do
+            loader_fn.(context)
+          rescue
+            _ -> nil
+          end
+
+        cond do
+          is_nil(loaded) ->
+            :not_found
+
+          authorization_module.resolver_module().authorized?(
+            subject,
+            authorization_module,
+            loaded,
+            action
+          ) ->
+            {:authorized, loaded}
+
+          true ->
+            :unauthorized
+        end
     end
   end
 

--- a/lib/permit_absinthe/schema/helpers.ex
+++ b/lib/permit_absinthe/schema/helpers.ex
@@ -30,13 +30,27 @@ defmodule Permit.Absinthe.Schema.Helpers do
 
   @doc """
   Returns a base query for a given resolution.
+
+  If a custom base_query function is provided in field_meta, it will be used.
+  Otherwise, falls back to the default behavior.
   """
-  def base_query(%{
-        resource_module: resource_module,
-        resolution: resolution,
-        params: params
-      }) do
+  def base_query(
+        %{
+          resource_module: resource_module,
+          resolution: resolution,
+          params: params
+        } = context
+      ) do
     field_meta = Meta.get_field_meta_from_resolution(resolution, :permit)
+
+    if is_function(field_meta[:base_query], 1) do
+      field_meta[:base_query].(context)
+    else
+      default_base_query(resource_module, params, field_meta)
+    end
+  end
+
+  defp default_base_query(resource_module, params, field_meta) do
     param = field_meta[:id_param_name] || :id
     field = field_meta[:id_struct_field_name] || :id
 

--- a/test/permit_absinthe/configurable_options_test.exs
+++ b/test/permit_absinthe/configurable_options_test.exs
@@ -1,0 +1,669 @@
+defmodule Permit.Absinthe.ConfigurableOptionsTest do
+  @moduledoc """
+  Tests for the new configurable options in permit macro.
+  """
+  use ExUnit.Case
+
+  alias Permit.AbsintheFakeApp.{Item, Repo, Setup, User}
+
+  @admin_user %User{id: 1, roles: ["admin"], permission_level: 100}
+  @regular_user %User{id: 2, roles: ["user"], permission_level: 1}
+  @custom_user %User{id: 3, roles: ["admin"], permission_level: 50}
+
+  setup_all do
+    Setup.setup_test_db()
+    :ok
+  end
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+
+    user1 = %User{id: 1, roles: ["admin"], permission_level: 100}
+    user2 = %User{id: 2, roles: ["user"], permission_level: 1}
+
+    Repo.insert!(user1)
+    Repo.insert!(user2)
+
+    item1 = %Item{id: 1, permission_level: 1, thread_name: "test1", owner_id: 1}
+    item2 = %Item{id: 2, permission_level: 50, thread_name: "test2", owner_id: 2}
+    item3 = %Item{id: 3, permission_level: 100, thread_name: "test3", owner_id: 1}
+
+    Repo.insert!(item1)
+    Repo.insert!(item2)
+    Repo.insert!(item3)
+
+    :ok
+  end
+
+  describe "fetch_subject option" do
+    test "uses custom fetch_subject function" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithCustomSubject(id: $id) {
+          id
+          threadName
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{custom_user: @custom_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithCustomSubject" => item}}} = result
+      assert item["id"] == "1"
+    end
+
+    test "returns error when custom fetch_subject returns nil" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithCustomSubject(id: $id) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{}
+        )
+
+      assert {:ok, %{data: %{"itemWithCustomSubject" => nil}, errors: errors}} = result
+      assert length(errors) > 0
+    end
+
+    test "handles fetch_subject that raises exception" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithRaisingFetchSubject(id: $id) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{current_user: @admin_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithRaisingFetchSubject" => nil}, errors: errors}} = result
+      assert length(errors) > 0
+    end
+  end
+
+  describe "base_query option" do
+    test "uses custom base_query for filtering" do
+      query = """
+      query GetItem($id: ID!, $ownerId: ID) {
+        itemWithCustomBaseQuery(id: $id, ownerId: $ownerId) {
+          id
+          ownerId
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1", "ownerId" => "1"},
+          context: %{current_user: @admin_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithCustomBaseQuery" => item}}} = result
+      assert item["id"] == "1"
+      assert item["ownerId"] == "1"
+    end
+
+    test "returns not found when base_query filters out the item" do
+      query = """
+      query GetItem($id: ID!, $ownerId: ID) {
+        itemWithCustomBaseQuery(id: $id, ownerId: $ownerId) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1", "ownerId" => "999"},
+          context: %{current_user: @admin_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithCustomBaseQuery" => nil}, errors: errors}} = result
+      assert Enum.any?(errors, fn err -> String.contains?(err.message, "Not found") end)
+    end
+  end
+
+  describe "finalize_query option" do
+    test "applies pagination with finalize_query" do
+      query = """
+      query GetItems($limit: Int, $offset: Int) {
+        itemsWithFinalizeQuery(limit: $limit, offset: $offset) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"limit" => 2, "offset" => 0},
+          context: %{current_user: @admin_user}
+        )
+
+      assert {:ok, %{data: %{"itemsWithFinalizeQuery" => items}}} = result
+      assert length(items) <= 2
+    end
+
+    test "works without pagination params" do
+      query = """
+      query GetItems {
+        itemsWithFinalizeQuery {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          context: %{current_user: @admin_user}
+        )
+
+      assert {:ok, %{data: %{"itemsWithFinalizeQuery" => items}}} = result
+      assert is_list(items)
+    end
+  end
+
+  describe "handle_unauthorized option" do
+    test "uses custom unauthorized handler" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithCustomUnauthorized(id: $id) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "3"},
+          context: %{current_user: @regular_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithCustomUnauthorized" => nil}, errors: errors}} = result
+
+      error = List.first(errors)
+      assert error.message =~ "Custom unauthorized"
+      assert error.message =~ "Permit.AbsintheFakeApp.Item"
+    end
+  end
+
+  describe "handle_not_found option" do
+    test "uses custom not found handler" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithCustomNotFound(id: $id) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "999"},
+          context: %{current_user: @admin_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithCustomNotFound" => nil}, errors: errors}} = result
+
+      error = List.first(errors)
+      assert error.message =~ "Custom not found"
+    end
+  end
+
+  describe "unauthorized_message option" do
+    test "uses custom unauthorized message" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithCustomMessage(id: $id) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "3"},
+          context: %{current_user: @regular_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithCustomMessage" => nil}, errors: errors}} = result
+
+      error = List.first(errors)
+      assert error.message == "You don't have permission to view this item"
+    end
+  end
+
+  describe "loader option" do
+    test "uses custom loader instead of Ecto" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithCustomLoader(id: $id) {
+          id
+          threadName
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{current_user: @admin_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithCustomLoader" => item}}} = result
+      assert item["threadName"] == "custom_loaded"
+    end
+
+    test "custom loader still respects authorization" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithCustomLoader(id: $id) {
+          id
+          threadName
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{current_user: @admin_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithCustomLoader" => item}}} = result
+      assert item["threadName"] == "custom_loaded"
+    end
+
+    test "custom loader denies access when no user is provided" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithCustomLoader(id: $id) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{}
+        )
+
+      assert {:ok, %{data: %{"itemWithCustomLoader" => nil}, errors: errors}} = result
+      assert length(errors) > 0
+    end
+
+    test "custom loader denies access to regular user without permission" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithCustomLoader(id: $id) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{current_user: @regular_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithCustomLoader" => nil}, errors: errors}} = result
+      assert length(errors) > 0
+    end
+
+    test "loader that returns nil results in not_found error" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithNilLoader(id: $id) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{current_user: @admin_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithNilLoader" => nil}, errors: errors}} = result
+      assert length(errors) > 0
+      assert Enum.any?(errors, fn err -> err.message =~ "Not found" end)
+    end
+
+    test "loader function that raises exception is handled gracefully" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithRaisingLoader(id: $id) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{current_user: @admin_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithRaisingLoader" => nil}, errors: errors}} = result
+      assert length(errors) > 0
+    end
+  end
+
+  describe "wrap_authorized option" do
+    test "wraps successful response" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithWrappedResponse(id: $id) {
+          id
+          threadName
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{current_user: @admin_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithWrappedResponse" => item}}} = result
+      assert item["id"] == "1"
+    end
+
+    test "wrap_authorized with error tuple is passed through" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithErrorWrap(id: $id) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{current_user: @admin_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithErrorWrap" => nil}, errors: errors}} = result
+      assert length(errors) > 0
+      assert Enum.any?(errors, fn err -> err.message =~ "Custom error from wrap" end)
+    end
+
+    test "handles wrap_authorized that raises exception" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithRaisingWrapAuthorized(id: $id) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{current_user: @admin_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithRaisingWrapAuthorized" => nil}, errors: errors}} = result
+      assert length(errors) > 0
+
+      assert Enum.any?(errors, fn err ->
+               err.message =~ "wrap_authorized function raised an exception"
+             end)
+    end
+
+    test "handles wrap_authorized with invalid string return type" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithInvalidWrapReturn(id: $id) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{current_user: @admin_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithInvalidWrapReturn" => nil}, errors: errors}} = result
+      assert length(errors) > 0
+
+      assert Enum.any?(errors, fn err ->
+               err.message =~ "wrap_authorized function returned invalid type"
+             end)
+    end
+
+    test "handles wrap_authorized with invalid tuple return type" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithInvalidWrapReturnTuple(id: $id) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{current_user: @admin_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithInvalidWrapReturnTuple" => nil}, errors: errors}} = result
+      assert length(errors) > 0
+
+      assert Enum.any?(errors, fn err ->
+               err.message =~ "wrap_authorized function returned invalid type"
+             end)
+    end
+  end
+
+  describe "handle_unauthorized option - error handling" do
+    test "handles handle_unauthorized that raises exception" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithRaisingUnauthorizedHandler(id: $id) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{}
+        )
+
+      assert {:ok, %{data: %{"itemWithRaisingUnauthorizedHandler" => nil}, errors: errors}} =
+               result
+
+      assert length(errors) > 0
+      assert Enum.any?(errors, fn err -> err.message =~ "Unauthorized" end)
+    end
+  end
+
+  describe "handle_not_found option - error handling" do
+    test "handles handle_not_found that raises exception" do
+      query = """
+      query GetItem($id: ID!) {
+        itemWithRaisingNotFoundHandler(id: $id) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{current_user: @admin_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithRaisingNotFoundHandler" => nil}, errors: errors}} = result
+      assert length(errors) > 0
+      assert Enum.any?(errors, fn err -> err.message =~ "Not found" end)
+    end
+  end
+
+  describe "combined options" do
+    test "multiple options work together" do
+      query = """
+      query GetItem($id: ID!, $ownerId: ID) {
+        itemWithCombinedOptions(id: $id, ownerId: $ownerId) {
+          id
+          ownerId
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1", "ownerId" => "1"},
+          context: %{custom_user: @custom_user}
+        )
+
+      assert {:ok, %{data: %{"itemWithCombinedOptions" => item}}} = result
+      assert item["id"] == "1"
+    end
+
+    test "combined options: custom unauthorized takes precedence over message" do
+      query = """
+      query GetItem($id: ID!, $ownerId: ID) {
+        itemWithCombinedOptions(id: $id, ownerId: $ownerId) {
+          id
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{}
+        )
+
+      assert {:ok, %{data: %{"itemWithCombinedOptions" => nil}, errors: errors}} = result
+
+      error = List.first(errors)
+      assert error.message == "Combined options: unauthorized"
+    end
+  end
+
+  describe "mutation with custom options" do
+    test "uses custom handle_unauthorized when user is unauthorized" do
+      mutation = """
+      mutation CreateItem($permissionLevel: Int, $threadName: String) {
+        createItemWithCustomOptions(permissionLevel: $permissionLevel, threadName: $threadName) {
+          id
+        }
+      }
+      """
+
+      unauthorized_user = %User{id: 999, roles: [], permission_level: 0}
+
+      result =
+        Absinthe.run(
+          mutation,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"permissionLevel" => 1, "threadName" => "test"},
+          context: %{current_user: unauthorized_user}
+        )
+
+      assert {:ok, %{data: %{"createItemWithCustomOptions" => nil}, errors: errors}} = result
+      assert length(errors) > 0
+
+      error = List.first(errors)
+      assert error.message =~ "Cannot create item"
+    end
+  end
+
+  describe "backwards compatibility" do
+    test "fields without new options still work" do
+      query = """
+      query GetItem($id: ID!) {
+        item(id: $id) {
+          id
+          threadName
+        }
+      }
+      """
+
+      result =
+        Absinthe.run(
+          query,
+          Permit.AbsintheFakeApp.Schema,
+          variables: %{"id" => "1"},
+          context: %{current_user: @admin_user}
+        )
+
+      assert {:ok, %{data: %{"item" => item}}} = result
+      assert item["id"] == "1"
+    end
+  end
+end

--- a/test/permit_absinthe/configurable_options_test.exs
+++ b/test/permit_absinthe/configurable_options_test.exs
@@ -470,6 +470,29 @@ defmodule Permit.Absinthe.ConfigurableOptionsTest do
       assert length(errors) > 0
     end
 
+    test "local function capture loader works without schema module qualification" do
+      query = """
+      query GetItems($ownerId: ID!) {
+        itemsWithLocalCaptureLoader(ownerId: $ownerId) {
+          id
+          ownerId
+          threadName
+        }
+      }
+      """
+
+      assert {:ok, %{data: %{"itemsWithLocalCaptureLoader" => items}}} =
+               Absinthe.run(
+                 query,
+                 Permit.AbsintheFakeApp.Schema,
+                 variables: %{"ownerId" => "1"},
+                 context: %{current_user: @admin_user}
+               )
+
+      assert is_list(items)
+      assert Enum.any?(items, &(&1["threadName"] == "external_1"))
+    end
+
     test "custom loader can return a list and filters authorized items" do
       query = """
       query GetItems {

--- a/test/support/absinthe_fake_app/schema.ex
+++ b/test/support/absinthe_fake_app/schema.ex
@@ -8,6 +8,8 @@ defmodule Permit.AbsintheFakeApp.Schema do
   alias Permit.Absinthe, as: PermitAbsinthe
   alias Permit.AbsintheFakeApp.{Item, Subitem, User}
 
+  import Ecto.Query
+
   # Custom types
   object :user do
     field(:id, :id)
@@ -115,6 +117,286 @@ defmodule Permit.AbsintheFakeApp.Schema do
         {:ok, current_user}
       end)
     end
+
+    field :item_with_custom_subject, :item do
+      arg(:id, non_null(:id))
+
+      permit(
+        action: :read,
+        fetch_subject: fn %{resolution: resolution} ->
+          get_in(resolution.context, [:custom_user])
+        end
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
+    field :item_with_custom_base_query, :item do
+      arg(:id, non_null(:id))
+      arg(:owner_id, :id)
+
+      permit(
+        action: :read,
+        base_query: fn %{params: params} ->
+          query = from(i in Item, where: i.id == ^params.id)
+
+          case params do
+            %{owner_id: owner_id} ->
+              where(query, [i], i.owner_id == ^owner_id)
+
+            _ ->
+              query
+          end
+        end
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
+    field :items_with_finalize_query, list_of(:item) do
+      arg(:limit, :integer)
+      arg(:offset, :integer)
+
+      permit(
+        action: :read,
+        finalize_query: fn query, %{params: params} ->
+          query =
+            case params do
+              %{limit: limit} -> limit(query, ^limit)
+              _ -> query
+            end
+
+          case params do
+            %{offset: offset} -> offset(query, ^offset)
+            _ -> query
+          end
+        end
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
+    field :item_with_custom_unauthorized, :item do
+      arg(:id, non_null(:id))
+
+      permit(
+        action: :read,
+        handle_unauthorized: fn %{action: action, resource_module: module} ->
+          {:error,
+           %{
+             message: "Custom unauthorized for #{action} on #{inspect(module)}",
+             code: "CUSTOM_FORBIDDEN"
+           }}
+        end
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
+    field :item_with_custom_not_found, :item do
+      arg(:id, non_null(:id))
+
+      permit(
+        action: :read,
+        handle_not_found: fn %{params: params} ->
+          {:error,
+           %{
+             message: "Custom not found",
+             code: "CUSTOM_NOT_FOUND",
+             params: params
+           }}
+        end
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
+    field :item_with_custom_message, :item do
+      arg(:id, non_null(:id))
+
+      permit(
+        action: :read,
+        unauthorized_message: "You don't have permission to view this item"
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
+    field :item_with_custom_loader, :item do
+      arg(:id, non_null(:id))
+
+      permit(
+        action: :read,
+        loader: fn %{params: %{id: id}} ->
+          %Item{
+            id: id,
+            permission_level: 1,
+            thread_name: "custom_loaded",
+            owner_id: 1
+          }
+        end
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
+    field :item_with_wrapped_response, :item do
+      arg(:id, non_null(:id))
+
+      permit(
+        action: :read,
+        wrap_authorized: fn item ->
+          {:ok, item}
+        end
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
+    field :item_with_combined_options, :item do
+      arg(:id, non_null(:id))
+      arg(:owner_id, :id)
+
+      permit(
+        action: :read,
+        base_query: fn %{params: params} ->
+          query = from(i in Item, where: i.id == ^params.id)
+
+          case params do
+            %{owner_id: owner_id} -> where(query, [i], i.owner_id == ^owner_id)
+            _ -> query
+          end
+        end,
+        fetch_subject: fn %{resolution: resolution} ->
+          resolution.context[:custom_user] || resolution.context[:current_user]
+        end,
+        handle_unauthorized: fn _ ->
+          {:error, "Combined options: unauthorized"}
+        end
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
+    field :item_with_nil_loader, :item do
+      arg(:id, non_null(:id))
+
+      permit(
+        action: :read,
+        loader: fn %{params: _params} ->
+          nil
+        end
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
+    field :item_with_raising_loader, :item do
+      arg(:id, non_null(:id))
+
+      permit(
+        action: :read,
+        loader: fn %{params: _params} ->
+          raise "Loader error"
+        end
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
+    field :item_with_error_wrap, :item do
+      arg(:id, non_null(:id))
+
+      permit(
+        action: :read,
+        wrap_authorized: fn _item ->
+          {:error, "Custom error from wrap"}
+        end
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
+    field :item_with_raising_fetch_subject, :item do
+      arg(:id, non_null(:id))
+
+      permit(
+        action: :read,
+        fetch_subject: fn %{resolution: _resolution} ->
+          raise "fetch_subject error"
+        end
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
+    field :item_with_raising_unauthorized_handler, :item do
+      arg(:id, non_null(:id))
+
+      permit(
+        action: :read,
+        handle_unauthorized: fn _ ->
+          raise "unauthorized handler error"
+        end
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
+    field :item_with_raising_not_found_handler, :item do
+      arg(:id, non_null(:id))
+
+      permit(
+        action: :read,
+        base_query: fn _ ->
+          from(i in Item, where: i.id == -999)
+        end,
+        handle_not_found: fn _ ->
+          raise "not found handler error"
+        end
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
+    field :item_with_raising_wrap_authorized, :item do
+      arg(:id, non_null(:id))
+
+      permit(
+        action: :read,
+        wrap_authorized: fn _item ->
+          raise "wrap_authorized error"
+        end
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
+    field :item_with_invalid_wrap_return, :item do
+      arg(:id, non_null(:id))
+
+      permit(
+        action: :read,
+        wrap_authorized: fn _item ->
+          "invalid return type"
+        end
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
+    field :item_with_invalid_wrap_return_tuple, :item do
+      arg(:id, non_null(:id))
+
+      permit(
+        action: :read,
+        wrap_authorized: fn _item ->
+          {:custom, "response"}
+        end
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
   end
 
   # Mutations
@@ -152,6 +434,33 @@ defmodule Permit.AbsintheFakeApp.Schema do
                  %{permission_level: permission_level, thread_name: thread_name},
                  %{context: %{loaded_resource: item}} ->
         {:ok, %{item | permission_level: permission_level, thread_name: thread_name}}
+      end)
+    end
+
+    field :create_item_with_custom_options, :item do
+      arg(:permission_level, :integer)
+      arg(:thread_name, :string)
+
+      permit(
+        action: :create,
+        handle_unauthorized: fn _ ->
+          {:error, %{message: "Cannot create item", code: "CREATE_FORBIDDEN"}}
+        end
+      )
+
+      middleware(Permit.Absinthe.Middleware.LoadAndAuthorize)
+
+      resolve(fn args, %{context: %{current_user: current_user}} ->
+        if current_user do
+          {:ok,
+           %Item{
+             permission_level: args.permission_level,
+             thread_name: args.thread_name,
+             owner_id: current_user.id
+           }}
+        else
+          {:error, "No user"}
+        end
       end)
     end
   end

--- a/test/support/absinthe_fake_app/schema.ex
+++ b/test/support/absinthe_fake_app/schema.ex
@@ -17,6 +17,121 @@ defmodule Permit.AbsintheFakeApp.Schema do
     ]
   end
 
+  def external_items_loader(%{params: %{owner_id: owner_id}}) do
+    external_items_for_owner(owner_id)
+  end
+
+  def fetch_subject_custom_user(%{resolution: resolution}) do
+    get_in(resolution.context, [:custom_user])
+  end
+
+  def item_with_custom_base_query(%{params: params}) do
+    query = from(i in Item, where: i.id == ^params.id)
+
+    case params do
+      %{owner_id: owner_id} -> where(query, [i], i.owner_id == ^owner_id)
+      _ -> query
+    end
+  end
+
+  def items_with_finalize_query(query, %{params: params}) do
+    query =
+      case params do
+        %{limit: limit} -> limit(query, ^limit)
+        _ -> query
+      end
+
+    case params do
+      %{offset: offset} -> offset(query, ^offset)
+      _ -> query
+    end
+  end
+
+  def handle_unauthorized_custom(%{action: action, resource_module: module}) do
+    {:error,
+     %{
+       message: "Custom unauthorized for #{action} on #{inspect(module)}",
+       code: "CUSTOM_FORBIDDEN"
+     }}
+  end
+
+  def handle_not_found_custom(%{params: params}) do
+    {:error,
+     %{
+       message: "Custom not found",
+       code: "CUSTOM_NOT_FOUND",
+       params: params
+     }}
+  end
+
+  def item_with_custom_loader(%{params: %{id: id}}) do
+    %Item{
+      id: id,
+      permission_level: 1,
+      thread_name: "custom_loaded",
+      owner_id: 1
+    }
+  end
+
+  def items_with_custom_loader(_context) do
+    [
+      %Item{id: 101, owner_id: 1, permission_level: 1, thread_name: "custom_list_admin"},
+      %Item{id: 102, owner_id: 2, permission_level: 1, thread_name: "custom_list_owner"},
+      %Item{id: 103, owner_id: 3, permission_level: 1, thread_name: "custom_list_inspector"}
+    ]
+  end
+
+  def items_with_nil_loader(_context), do: nil
+
+  def item_with_empty_list_loader(_context), do: []
+
+  def items_with_wrapped_response_loader(_context) do
+    [
+      %Item{id: 201, owner_id: 1, permission_level: 1, thread_name: "wrap_1"},
+      %Item{id: 202, owner_id: 1, permission_level: 1, thread_name: "wrap_2"}
+    ]
+  end
+
+  def items_with_wrapped_response_wrap(items), do: {:ok, Enum.reverse(items)}
+
+  def items_with_custom_subject_fetch_subject(%{resolution: resolution}) do
+    resolution.context[:custom_user] || resolution.context[:current_user]
+  end
+
+  def items_with_custom_subject_base_query(_context),
+    do: from(i in Item, where: i.permission_level >= 1)
+
+  def handler_wins_unauthorized(_ctx), do: {:error, "Handler wins"}
+
+  def base_query_item_by_id(%{params: %{id: id}}), do: from(i in Item, where: i.id == ^id)
+
+  def wrap_authorized_identity(item), do: {:ok, item}
+
+  def combined_options_unauthorized(_ctx), do: {:error, "Combined options: unauthorized"}
+
+  def item_with_nil_loader(%{params: _params}), do: nil
+
+  def item_with_raising_loader(%{params: _params}), do: raise("Loader error")
+
+  def wrap_error(_item), do: {:error, "Custom error from wrap"}
+
+  def raising_fetch_subject(%{resolution: _resolution}), do: raise("fetch_subject error")
+
+  def raising_unauthorized_handler(_ctx), do: raise("unauthorized handler error")
+
+  def raising_not_found_base_query(_ctx), do: from(i in Item, where: i.id == -999)
+
+  def raising_not_found_handler(_ctx), do: raise("not found handler error")
+
+  def raising_wrap_authorized(_item), do: raise("wrap_authorized error")
+
+  def invalid_wrap_return(_item), do: "invalid return type"
+
+  def invalid_wrap_return_tuple(_item), do: {:custom, "response"}
+
+  def create_item_with_custom_options_unauthorized(_ctx),
+    do: {:error, %{message: "Cannot create item", code: "CREATE_FORBIDDEN"}}
+
   # Custom types
   object :user do
     field(:id, :id)
@@ -120,6 +235,17 @@ defmodule Permit.AbsintheFakeApp.Schema do
       resolve(&PermitAbsinthe.load_and_authorize/2)
     end
 
+    field :items_with_local_capture_loader, list_of(:item) do
+      arg(:owner_id, non_null(:id))
+
+      permit(
+        action: :read,
+        loader: &external_items_loader/1
+      )
+
+      resolve(&PermitAbsinthe.load_and_authorize/2)
+    end
+
     field :user, :user do
       arg(:id, non_null(:id))
 
@@ -143,9 +269,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        fetch_subject: fn %{resolution: resolution} ->
-          get_in(resolution.context, [:custom_user])
-        end
+        fetch_subject: &fetch_subject_custom_user/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -157,17 +281,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        base_query: fn %{params: params} ->
-          query = from(i in Item, where: i.id == ^params.id)
-
-          case params do
-            %{owner_id: owner_id} ->
-              where(query, [i], i.owner_id == ^owner_id)
-
-            _ ->
-              query
-          end
-        end
+        base_query: &item_with_custom_base_query/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -179,18 +293,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        finalize_query: fn query, %{params: params} ->
-          query =
-            case params do
-              %{limit: limit} -> limit(query, ^limit)
-              _ -> query
-            end
-
-          case params do
-            %{offset: offset} -> offset(query, ^offset)
-            _ -> query
-          end
-        end
+        finalize_query: &items_with_finalize_query/2
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -201,13 +304,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        handle_unauthorized: fn %{action: action, resource_module: module} ->
-          {:error,
-           %{
-             message: "Custom unauthorized for #{action} on #{inspect(module)}",
-             code: "CUSTOM_FORBIDDEN"
-           }}
-        end
+        handle_unauthorized: &handle_unauthorized_custom/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -218,14 +315,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        handle_not_found: fn %{params: params} ->
-          {:error,
-           %{
-             message: "Custom not found",
-             code: "CUSTOM_NOT_FOUND",
-             params: params
-           }}
-        end
+        handle_not_found: &handle_not_found_custom/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -247,14 +337,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        loader: fn %{params: %{id: id}} ->
-          %Item{
-            id: id,
-            permission_level: 1,
-            thread_name: "custom_loaded",
-            owner_id: 1
-          }
-        end
+        loader: &item_with_custom_loader/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -263,13 +346,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
     field :items_with_custom_loader, list_of(:item) do
       permit(
         action: :read,
-        loader: fn _context ->
-          [
-            %Item{id: 101, owner_id: 1, permission_level: 1, thread_name: "custom_list_admin"},
-            %Item{id: 102, owner_id: 2, permission_level: 1, thread_name: "custom_list_owner"},
-            %Item{id: 103, owner_id: 3, permission_level: 1, thread_name: "custom_list_inspector"}
-          ]
-        end
+        loader: &items_with_custom_loader/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -278,7 +355,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
     field :items_with_nil_loader, list_of(:item) do
       permit(
         action: :read,
-        loader: fn _context -> nil end
+        loader: &items_with_nil_loader/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -289,7 +366,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        loader: fn _context -> [] end
+        loader: &item_with_empty_list_loader/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -298,15 +375,8 @@ defmodule Permit.AbsintheFakeApp.Schema do
     field :items_with_wrapped_response, list_of(:item) do
       permit(
         action: :read,
-        loader: fn _context ->
-          [
-            %Item{id: 201, owner_id: 1, permission_level: 1, thread_name: "wrap_1"},
-            %Item{id: 202, owner_id: 1, permission_level: 1, thread_name: "wrap_2"}
-          ]
-        end,
-        wrap_authorized: fn items ->
-          {:ok, Enum.reverse(items)}
-        end
+        loader: &items_with_wrapped_response_loader/1,
+        wrap_authorized: &items_with_wrapped_response_wrap/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -315,10 +385,8 @@ defmodule Permit.AbsintheFakeApp.Schema do
     field :items_with_custom_subject, list_of(:item) do
       permit(
         action: :read,
-        fetch_subject: fn %{resolution: resolution} ->
-          resolution.context[:custom_user] || resolution.context[:current_user]
-        end,
-        base_query: fn _ -> from(i in Item, where: i.permission_level >= 1) end
+        fetch_subject: &items_with_custom_subject_fetch_subject/1,
+        base_query: &items_with_custom_subject_base_query/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -329,9 +397,9 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        handle_unauthorized: fn _ -> {:error, "Handler wins"} end,
+        handle_unauthorized: &handler_wins_unauthorized/1,
         unauthorized_message: "Should not be used",
-        base_query: fn %{params: %{id: id}} -> from(i in Item, where: i.id == ^id) end
+        base_query: &base_query_item_by_id/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -342,9 +410,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        wrap_authorized: fn item ->
-          {:ok, item}
-        end
+        wrap_authorized: &wrap_authorized_identity/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -356,20 +422,9 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        base_query: fn %{params: params} ->
-          query = from(i in Item, where: i.id == ^params.id)
-
-          case params do
-            %{owner_id: owner_id} -> where(query, [i], i.owner_id == ^owner_id)
-            _ -> query
-          end
-        end,
-        fetch_subject: fn %{resolution: resolution} ->
-          resolution.context[:custom_user] || resolution.context[:current_user]
-        end,
-        handle_unauthorized: fn _ ->
-          {:error, "Combined options: unauthorized"}
-        end
+        base_query: &item_with_custom_base_query/1,
+        fetch_subject: &items_with_custom_subject_fetch_subject/1,
+        handle_unauthorized: &combined_options_unauthorized/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -380,9 +435,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        loader: fn %{params: _params} ->
-          nil
-        end
+        loader: &item_with_nil_loader/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -393,9 +446,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        loader: fn %{params: _params} ->
-          raise "Loader error"
-        end
+        loader: &item_with_raising_loader/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -406,9 +457,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        wrap_authorized: fn _item ->
-          {:error, "Custom error from wrap"}
-        end
+        wrap_authorized: &wrap_error/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -419,9 +468,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        fetch_subject: fn %{resolution: _resolution} ->
-          raise "fetch_subject error"
-        end
+        fetch_subject: &raising_fetch_subject/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -432,9 +479,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        handle_unauthorized: fn _ ->
-          raise "unauthorized handler error"
-        end
+        handle_unauthorized: &raising_unauthorized_handler/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -445,12 +490,8 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        base_query: fn _ ->
-          from(i in Item, where: i.id == -999)
-        end,
-        handle_not_found: fn _ ->
-          raise "not found handler error"
-        end
+        base_query: &raising_not_found_base_query/1,
+        handle_not_found: &raising_not_found_handler/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -461,9 +502,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        wrap_authorized: fn _item ->
-          raise "wrap_authorized error"
-        end
+        wrap_authorized: &raising_wrap_authorized/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -474,9 +513,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        wrap_authorized: fn _item ->
-          "invalid return type"
-        end
+        wrap_authorized: &invalid_wrap_return/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -487,9 +524,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :read,
-        wrap_authorized: fn _item ->
-          {:custom, "response"}
-        end
+        wrap_authorized: &invalid_wrap_return_tuple/1
       )
 
       resolve(&PermitAbsinthe.load_and_authorize/2)
@@ -540,9 +575,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(
         action: :create,
-        handle_unauthorized: fn _ ->
-          {:error, %{message: "Cannot create item", code: "CREATE_FORBIDDEN"}}
-        end
+        handle_unauthorized: &create_item_with_custom_options_unauthorized/1
       )
 
       middleware(Permit.Absinthe.Middleware.LoadAndAuthorize)


### PR DESCRIPTION
# Pull Request

## Description

This PR extends the `permit` macro to support configurable options similar to those available in [Permit.Phoenix](https://hexdocs.pm/permit_phoenix/Permit.Phoenix.html).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Related issues

Closes #4 

## Changes made

Extended permit macro to accept new configuration options:

- `:base_query` - custom base query function for resource loading
- `:finalize_query` - post-processing function for query modification
- `:fetch_subject` - custom current user extraction
- `:handle_unauthorized` - custom unauthorized error handling
- `:handle_not_found` - custom not found error handling
- `:unauthorized_message` - string message for unauthorized cases
- `:loader` - custom loader for non-Ecto data sources
- `:wrap_authorized` - to customize the default `{:ok, loaded_resource}` behaviour when the resource is loaded and authorized