### PR TITLE
Fix create action authorization in LoadAndAuthorize middleware/resolver

### DIFF
--- a/lib/permit_absinthe/resolvers/load_and_authorize.ex
+++ b/lib/permit_absinthe/resolvers/load_and_authorize.ex
@@ -472,6 +472,6 @@ defmodule Permit.Absinthe.Resolvers.LoadAndAuthorize do
   defp create_action?(action, authorization_module) do
     actions_module = authorization_module.actions_module()
     grouping = actions_module.grouping_schema()
-    action == :create or :create in (Map.get(grouping, action) || [])
+    action == :create or :create in Map.get(grouping, action, [])
   end
 end

--- a/lib/permit_absinthe/resolvers/load_and_authorize.ex
+++ b/lib/permit_absinthe/resolvers/load_and_authorize.ex
@@ -156,28 +156,32 @@ defmodule Permit.Absinthe.Resolvers.LoadAndAuthorize do
 
     subject = fetch_subject(resolution_context, field_meta)
 
-    if is_nil(subject) do
-      handle_unauthorized(resolution_context, field_meta)
-    else
-      arity = determine_arity(resolution)
+    # For create actions there is no existing record to load, so we check
+    # authorization against a blank struct. This ensures field-level conditions
+    # (e.g. owner_id: user.id) are evaluated against nil rather than bypassed
+    # by the module-atom shortcut in ParsedCondition.satisfied?/3, which
+    # would otherwise allow any conditioned rule to pass unconditionally.
+    cond do
+      is_nil(subject) ->
+        handle_unauthorized(resolution_context, field_meta)
 
-      case authorize_and_load(
-             subject,
-             authorization_module,
-             module,
-             action,
-             resolution_context,
-             arity
-           ) do
-        {:authorized, resource} ->
-          wrap_authorized_response(resource, field_meta, resolution_context.resolution)
+      create_action?(action, authorization_module) ->
+        blank = module.__struct__()
 
-        :unauthorized ->
+        if authorization_module.resolver_module().authorized?(subject, authorization_module, blank, action) do
+          wrap_authorized_response(nil, field_meta, resolution_context.resolution)
+        else
           handle_unauthorized(resolution_context, field_meta)
+        end
 
-        :not_found ->
-          handle_not_found(resolution_context, field_meta)
-      end
+      true ->
+        arity = determine_arity(resolution)
+
+        case authorize_and_load(subject, authorization_module, module, action, resolution_context, arity) do
+          {:authorized, resource} -> wrap_authorized_response(resource, field_meta, resolution_context.resolution)
+          :unauthorized -> handle_unauthorized(resolution_context, field_meta)
+          :not_found -> handle_not_found(resolution_context, field_meta)
+        end
     end
   end
 
@@ -460,4 +464,16 @@ defmodule Permit.Absinthe.Resolvers.LoadAndAuthorize do
   defp has_list_type?(%Absinthe.Type.List{}), do: true
   defp has_list_type?(%{of_type: inner_type}), do: has_list_type?(inner_type)
   defp has_list_type?(_), do: false
+
+  # Create actions have no pre-existing record to load — authorization is a
+  # pure capability check on the resource module, not a record instance.
+  # We detect this by checking if the action is :create or is defined in the
+  # grouping schema as requiring :create (e.g. a custom :new action that maps to :create).
+  defp create_action?(action, authorization_module) do
+    actions_module = authorization_module.actions_module()
+    grouping = actions_module.grouping_schema()
+    action == :create or :create in (Map.get(grouping, action) || [])
+  rescue
+    _ -> action == :create
+  end
 end

--- a/lib/permit_absinthe/resolvers/load_and_authorize.ex
+++ b/lib/permit_absinthe/resolvers/load_and_authorize.ex
@@ -473,7 +473,5 @@ defmodule Permit.Absinthe.Resolvers.LoadAndAuthorize do
     actions_module = authorization_module.actions_module()
     grouping = actions_module.grouping_schema()
     action == :create or :create in (Map.get(grouping, action) || [])
-  rescue
-    _ -> action == :create
   end
 end


### PR DESCRIPTION
## Problem

When `Permit.Absinthe.Middleware.LoadAndAuthorize` was used on a create mutation (e.g. `action: :create`), it would call `Permit.Ecto.Resolver.resolve/6` with arity `:one` — which tries to load an existing record from the DB. Since create mutations have no `:id` argument, the query ran unscoped (e.g. `SELECT * FROM comments WHERE true`) and crashed with `Ecto.MultipleResultsError` when more than one row existed.

Additionally, calling `authorized?/4` with the resource **module** (an atom) as the third argument bypasses field-level condition evaluation in `ParsedCondition.satisfied?/3` — any non-nil condition is treated as unconditionally truthy, allowing users with conditioned rules like `all(Item, owner_id: id)` to pass the create check regardless of whether they should.

## Changes

**`lib/permit_absinthe/resolvers/load_and_authorize.ex`**

- Added a `create_action?/2` helper that detects create-like actions by checking the actions module's grouping schema (covers both `:create` directly and custom actions that map to `:create`).
- Introduced a distinct code path in `load_and_authorize/2` for create actions: instead of attempting to load a record, it calls `authorized?/4` against a **blank struct** (`module.__struct__()`). This ensures field-level conditions are evaluated against `nil` values rather than short-circuited, so only unconditional `create(Resource)` rules grant access.
- Refactored the nested `if/else` branching into a `cond do` expression for clarity.

## Behaviour after this fix

- Create mutations no longer crash with `Ecto.MultipleResultsError`.
- Conditioned rules (e.g. `all(Resource, owner_id: id)`) correctly **deny** creation — only unconditional `create(Resource)` rules authorize it.
- The resolver still runs after the middleware; `context.loaded_resource` is `nil` for create actions (as expected, since there is no record to load).

## Known limitation

Create authorization based on the **fields of the record being created** (e.g. `create(Comment, user_id: user_id)` or `create(Comment, note: [public: true])`) is not yet supported — conditions are checked against a blank struct, so input-derived fields are not visible at authorization time. This is a deeper limitation of `permit` itself (no concept of authorizing a creation intent against partial attributes) and is out of scope for this fix.