### PR TITLE
Shorten middleware module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Here's a quick table outlining which feature you should pick when plugging in Pe
 | If you need... | Use | Why |
 |---|---|---|
 | Simple query resolver | `resolve &load_and_authorize/2` | Lowest boilerplate for standard resource reads |
-| &bull; Query resolver + custom processing<br>&bull; Mutation  | `Permit.Absinthe.Middleware.LoadAndAuthorize` | Keeps full resolver control while reusing Permit loading/authorization |
+| &bull; Query resolver + custom processing<br>&bull; Mutation  | `Permit.Absinthe.Middleware` | Keeps full resolver control while reusing Permit loading/authorization |
 | Association loading | `resolve &authorized_dataloader/3` | Preserves Dataloader batching and enforces Permit rules |
 | Authorization declared explicitly in schema directives | `directives: [:load_and_authorize]` | Makes authorization behavior more visible at schema level |
 | Non-standard authorization or loading flow | Vanilla Permit calls inside your resolver | Maximum flexibility for advanced/custom cases |
@@ -164,7 +164,7 @@ end
 
 ### Load & authorize using Absinthe Middleware
 
-In mutations, or when custom and more complex resolution logic is required, the `Permit.Absinthe.Middleware.LoadAndAuthorize` can be used, preloading the resource (or list of resources) into `context`, which then can be consumed in a custom Absinthe resolver function.
+In mutations, or when custom and more complex resolution logic is required, the `Permit.Absinthe.Middleware` can be used, preloading the resource (or list of resources) into `context`, which then can be consumed in a custom Absinthe resolver function.
 
 ```elixir
   query do
@@ -172,7 +172,7 @@ In mutations, or when custom and more complex resolution logic is required, the 
     field :articles, list_of(:article) do
       permit action: :read
 
-      middleware Permit.Absinthe.Middleware.LoadAndAuthorize
+      middleware Permit.Absinthe.Middleware
 
       resolve(fn _parent, _args, %{context: context} = _resolution ->
         # ...
@@ -188,7 +188,7 @@ In mutations, or when custom and more complex resolution logic is required, the 
     field :article, :article do
       permit action: :read
 
-      middleware Permit.Absinthe.Middleware.LoadAndAuthorize
+      middleware Permit.Absinthe.Middleware
 
       arg :id, non_null(:id)
 
@@ -211,7 +211,7 @@ In mutations, or when custom and more complex resolution logic is required, the 
       arg(:name, non_null(:string))
       arg(:content, non_null(:string))
 
-      middleware Permit.Absinthe.Middleware.LoadAndAuthorize
+      middleware Permit.Absinthe.Middleware
 
       resolve(fn _, %{name: name, content: content}, %{context: context} ->
         case Blog.Content.update_article(context.loaded_resource, %{name: name, content: content}) do

--- a/lib/permit_absinthe.ex
+++ b/lib/permit_absinthe.ex
@@ -46,7 +46,7 @@ defmodule Permit.Absinthe do
 
       field :update_post, :post do
         permit action: :update
-        middleware Permit.Absinthe.Middleware.LoadAndAuthorize
+        middleware Permit.Absinthe.Middleware
         resolve fn _, args, %{context: %{loaded_resource: post}} ->
           # post is already loaded and authorized
           MyApp.Blog.update_post(post, args)

--- a/lib/permit_absinthe/middleware.ex
+++ b/lib/permit_absinthe/middleware.ex
@@ -1,0 +1,67 @@
+defmodule Permit.Absinthe.Middleware do
+  @moduledoc """
+  Middleware for loading and authorizing resources in Absinthe. Uses the raw
+  resolver function defined in `Permit.Absinthe.Resolvers.LoadAndAuthorize` to
+  put the resolution outcome in `:loaded_resource` or `:loaded_resources`
+  (depending on whether it's an index-like or a single-item action).
+
+  Useful in mutations where it's not enough to just load a resource, or whenever
+  you otherwise need to process it after loading.
+
+  ## Usage, mechanism and configuration
+
+  See `Permit.Absinthe.Resolvers.LoadAndAuthorize` for details on resolution of
+  authorized records in Permit.Absinthe. The middleware delegates
+
+  ### Example
+
+  ```elixir
+  mutation do
+    @desc "Update an article"
+    field :update_article, :article do
+      permit action: :update
+
+      arg(:id, non_null(:id))
+      arg(:name, non_null(:string))
+      arg(:content, non_null(:string))
+
+      middleware Permit.Absinthe.Middleware
+
+      resolve(fn _, %{name: name, content: content}, %{context: context} ->
+        case Blog.Content.update_article(context.loaded_resource, %{name: name, content: content}) do
+          {:ok, article} ->
+            {:ok, article}
+
+          {:error, changeset} ->
+            {:error, "Could not update article"}
+        end
+      end)
+    end
+  end
+  ```
+  """
+  alias Permit.Absinthe.Resolvers.LoadAndAuthorize
+
+  @behaviour Absinthe.Middleware
+
+  @impl true
+  def call(resolution, _) do
+    case LoadAndAuthorize.load_and_authorize(
+           resolution.arguments,
+           resolution
+         ) do
+      {:ok, resource} ->
+        key =
+          case resource do
+            list when is_list(list) -> :loaded_resources
+            _ -> :loaded_resource
+          end
+
+        new_context = Map.put(resolution.context, key, resource)
+        %{resolution | context: new_context}
+
+      {:error, error} ->
+        Absinthe.Resolution.put_result(resolution, {:error, error})
+    end
+  end
+end

--- a/lib/permit_absinthe/middleware/load_and_authorize.ex
+++ b/lib/permit_absinthe/middleware/load_and_authorize.ex
@@ -1,67 +1,19 @@
 defmodule Permit.Absinthe.Middleware.LoadAndAuthorize do
   @moduledoc """
-  Middleware for loading and authorizing resources in Absinthe. Uses the raw
-  resolver function defined in `Permit.Absinthe.Resolvers.LoadAndAuthorize` to
-  put the resolution outcome in `:loaded_resource` or `:loaded_resources`
-  (depending on whether it's an index-like or a single-item action).
-
-  Useful in mutations where it's not enough to just load a resource, or whenever
-  you otherwise need to process it after loading.
-
-  ## Usage, mechanism and configuration
-
-  See `Permit.Absinthe.Resolvers.LoadAndAuthorize` for details on resolution of
-  authorized records in Permit.Absinthe. The middleware delegates
-
-  ### Example
-
-  ```elixir
-  mutation do
-    @desc "Update an article"
-    field :update_article, :article do
-      permit action: :update
-
-      arg(:id, non_null(:id))
-      arg(:name, non_null(:string))
-      arg(:content, non_null(:string))
-
-      middleware Permit.Absinthe.Middleware.LoadAndAuthorize
-
-      resolve(fn _, %{name: name, content: content}, %{context: context} ->
-        case Blog.Content.update_article(context.loaded_resource, %{name: name, content: content}) do
-          {:ok, article} ->
-            {:ok, article}
-
-          {:error, changeset} ->
-            {:error, "Could not update article"}
-        end
-      end)
-    end
-  end
-  ```
+  Deprecated. Use `Permit.Absinthe.Middleware` instead.
   """
-  alias Permit.Absinthe.Resolvers.LoadAndAuthorize
+
+  @deprecated "Use Permit.Absinthe.Middleware instead"
 
   @behaviour Absinthe.Middleware
 
   @impl true
-  def call(resolution, _) do
-    case LoadAndAuthorize.load_and_authorize(
-           resolution.arguments,
-           resolution
-         ) do
-      {:ok, resource} ->
-        key =
-          case resource do
-            list when is_list(list) -> :loaded_resources
-            _ -> :loaded_resource
-          end
+  def call(resolution, opts) do
+    IO.warn(
+      "Permit.Absinthe.Middleware.LoadAndAuthorize is deprecated, use Permit.Absinthe.Middleware instead",
+      []
+    )
 
-        new_context = Map.put(resolution.context, key, resource)
-        %{resolution | context: new_context}
-
-      {:error, error} ->
-        Absinthe.Resolution.put_result(resolution, {:error, error})
-    end
+    Permit.Absinthe.Middleware.call(resolution, opts)
   end
 end

--- a/lib/permit_absinthe/schema/prototype.ex
+++ b/lib/permit_absinthe/schema/prototype.ex
@@ -43,7 +43,7 @@ defmodule Permit.Absinthe.Schema.Prototype do
           _ -> :one
         end
 
-      %{node | middleware: [{Permit.Absinthe.Middleware.LoadAndAuthorize, arity} | existing]}
+      %{node | middleware: [{Permit.Absinthe.Middleware, arity} | existing]}
     end)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule Permit.Absinthe.MixProject do
       groups_for_modules: [
         "Load & Authorize": [
           Permit.Absinthe.Resolvers.LoadAndAuthorize,
-          Permit.Absinthe.Middleware.LoadAndAuthorize
+          Permit.Absinthe.Middleware
         ],
         Dataloader: [
           Permit.Absinthe.Resolvers.Dataloader

--- a/test/support/absinthe_fake_app/schema.ex
+++ b/test/support/absinthe_fake_app/schema.ex
@@ -558,7 +558,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
 
       permit(action: :update)
 
-      middleware(Permit.Absinthe.Middleware.LoadAndAuthorize)
+      middleware(Permit.Absinthe.Middleware)
 
       resolve(fn _,
                  %{permission_level: permission_level, thread_name: thread_name},
@@ -576,7 +576,7 @@ defmodule Permit.AbsintheFakeApp.Schema do
         handle_unauthorized: &create_item_with_custom_options_unauthorized/1
       )
 
-      middleware(Permit.Absinthe.Middleware.LoadAndAuthorize)
+      middleware(Permit.Absinthe.Middleware)
 
       resolve(fn args, %{context: %{current_user: current_user}} ->
         if current_user do


### PR DESCRIPTION
Shorten middleware module name to just `(...)Middleware` - there's no other middleware to speak of so there's no point maintaining the longer name now.